### PR TITLE
stabilize versions and declutter output

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ The following environment was used for the examples.
 
 ```bash
 $ dotnet --version
-8.0.100-rc.2.23502.2
+8.0.100
 $ docker --version
 Docker version 24.0.7, build afdd53b
 $ cat /etc/os-release | head -n 1

--- a/aspnetcore.md
+++ b/aspnetcore.md
@@ -66,11 +66,10 @@ $ dotnet publish -p:PublishProfile=DefaultContainer -p:ContainerFamily=jammy-chi
 MSBuild version 17.8.0+6cdef4241 for .NET
   Determining projects to restore...
   Restored /home/rich/hello-aspnet/hello-aspnet.csproj (in 471 ms).
-/home/rich/dotnet-rc2/sdk/8.0.100-rc.2.23502.2/Sdks/Microsoft.NET.Sdk/targets/Microsoft.NET.RuntimeIdentifierInference.targets(311,5): message NETSDK1057: You are using a preview version of .NET. See: https://aka.ms/dotnet-support-policy [/home/rich/hello-aspnet/hello-aspnet.csproj]
   hello-aspnet -> /home/rich/hello-aspnet/bin/Release/net8.0/linux-x64/hello-aspnet.dll
   Optimizing assemblies for size. This process might take a while.
   hello-aspnet -> /home/rich/hello-aspnet/bin/Release/net8.0/linux-x64/publish/
-  Building image 'hello-aspnet' with tags 'latest' on top of base image 'mcr.microsoft.com/dotnet/runtime-deps:8.0.0-rc.2-jammy-chiseled'.
+  Building image 'hello-aspnet' with tags 'latest' on top of base image 'mcr.microsoft.com/dotnet/runtime-deps:8.0-jammy-chiseled'.
   Pushed image 'hello-aspnet:latest' to local registry via 'docker'.
 $ docker images hello-aspnet
 REPOSITORY     TAG       IMAGE ID       CREATED          SIZE

--- a/cross-compilation.md
+++ b/cross-compilation.md
@@ -84,7 +84,7 @@ Add package to `dotnetapp`.
 ```bash
 $ pwd
 /home/rich/git/dotnet-docker/samples/dotnetapp
-$ dotnet add package Microsoft.NET.Build.Containers --version 8.0.100-rc.2.23480.5
+$ dotnet add package Microsoft.NET.Build.Containers --version 8.0.100
 ```
 
 Publish app for Arm64 (on x64 machine).
@@ -94,10 +94,9 @@ $ dotnet publish /t:PublishContainer -a arm64
 MSBuild version 17.8.0+6cdef4241 for .NET
   Determining projects to restore...
   Restored /home/rich/git/dotnet-docker/samples/dotnetapp/dotnetapp.csproj (in 171 ms).
-/home/rich/dotnet-rc2/sdk/8.0.100-rc.2.23502.2/Sdks/Microsoft.NET.Sdk/targets/Microsoft.NET.RuntimeIdentifierInference.targets(311,5): message NETSDK1057: You are using a preview version of .NET. See: https://aka.ms/dotnet-support-policy [/home/rich/git/dotnet-docker/samples/dotnetapp/dotnetapp.csproj]
   dotnetapp -> /home/rich/git/dotnet-docker/samples/dotnetapp/bin/Release/net8.0/linux-arm64/dotnetapp.dll
   dotnetapp -> /home/rich/git/dotnet-docker/samples/dotnetapp/bin/Release/net8.0/linux-arm64/publish/
-  Building image 'dotnetapp' with tags 'latest' on top of base image 'mcr.microsoft.com/dotnet/runtime:8.0.0-rc.2'.
+  Building image 'dotnetapp' with tags 'latest' on top of base image 'mcr.microsoft.com/dotnet/runtime:8.0'.
   Pushed image 'dotnetapp:latest' to local registry via 'docker'.
 ```
 
@@ -122,7 +121,6 @@ MSBuild version 17.8.3+195e7f5a3 for .NET
   Determining projects to restore...
   Restored /source/releasesapi.csproj (in 12.03 sec).
 /usr/share/dotnet/sdk/8.0.100-rtm.23523.2/Current/SolutionFile/ImportAfter/Microsoft.NET.Sdk.Solution.targets(36,5): warning NETSDK1194: The "--output" option isn't supported when building a solution. Specifying a solution-level output path results in all projects copying outputs to the same directory, which can lead to inconsistent builds. [/source/releasesapi.sln]
-/usr/share/dotnet/sdk/8.0.100-rtm.23523.2/Sdks/Microsoft.NET.Sdk/targets/Microsoft.NET.RuntimeIdentifierInference.targets(311,5): message NETSDK1057: You are using a preview version of .NET. See: https://aka.ms/dotnet-support-policy [/source/releasesapi.csproj]
   releasesapi -> /source/bin/Release/net8.0/linux-arm64/releasesapi.dll
   Generating native code
   releasesapi -> /source/app/

--- a/publish-in-sdk-container.md
+++ b/publish-in-sdk-container.md
@@ -149,7 +149,6 @@ $ docker run --rm -it -v $(pwd):/source -w /source mcr.microsoft.com/dotnet/nigh
 MSBuild version 17.8.3+195e7f5a3 for .NET
   Determining projects to restore...
   Restored /source/hello-native-api.csproj (in 8.1 sec).
-/usr/share/dotnet/sdk/8.0.100-rtm.23523.2/Sdks/Microsoft.NET.Sdk/targets/Microsoft.NET.RuntimeIdentifierInference.targets(311,5): message NETSDK1057: You are using a preview version of .NET. See: https://aka.ms/dotnet-support-policy [/source/hello-native-api.csproj]
   hello-native-api -> /source/bin/Release/net8.0/linux-x64/hello-native-api.dll
   hello-native-api -> /source/bin/Release/net8.0/linux-x64/publish/
   Building image 'hello-native-api' with tags 'latest' on top of base image 'mcr.microsoft.com/dotnet/nightly/runtime-deps:8.0-jammy-chiseled-aot'.
@@ -186,7 +185,6 @@ $ docker run --rm -it -v $(pwd):/source -w /source -v /home/rich/.docker:/root/.
 MSBuild version 17.8.3+195e7f5a3 for .NET
   Determining projects to restore...
   Restored /source/hello-native-api.csproj (in 8.47 sec).
-/usr/share/dotnet/sdk/8.0.100-rtm.23523.2/Sdks/Microsoft.NET.Sdk/targets/Microsoft.NET.RuntimeIdentifierInference.targets(311,5): message NETSDK1057: You are using a preview version of .NET. See: https://aka.ms/dotnet-support-policy [/source/hello-native-api.csproj]
   hello-native-api -> /source/bin/Release/net8.0/linux-x64/hello-native-api.dll
   hello-native-api -> /source/bin/Release/net8.0/linux-x64/publish/
   Building image 'richlander/hello-native-api' with tags 'latest' on top of base image 'mcr.microsoft.com/dotnet/nightly/runtime-deps:8.0-jammy-chiseled-aot'.
@@ -244,7 +242,6 @@ $ $ docker run --add-host=host.docker.internal:host-gateway --rm -it -v $(pwd):/
 MSBuild version 17.8.3+195e7f5a3 for .NET
   Determining projects to restore...
   Restored /source/hello-native-api.csproj (in 4.29 sec).
-/usr/share/dotnet/sdk/8.0.100-rtm.23523.2/Sdks/Microsoft.NET.Sdk/targets/Microsoft.NET.RuntimeIdentifierInference.targets(311,5): message NETSDK1057: You are using a preview version of .NET. See: https://aka.ms/dotnet-support-policy [/source/hello-native-api.csproj]
   hello-native-api -> /source/bin/Release/net8.0/linux-x64/hello-native-api.dll
   hello-native-api -> /source/bin/Release/net8.0/linux-x64/publish/
 /usr/share/dotnet/sdk/8.0.100-rtm.23523.2/Containers/build/Microsoft.NET.Build.Containers.targets(117,5): error CONTAINER2012: Could not recognize registry 'http://localhost:5000'. [/source/hello-native-api.csproj]

--- a/publish-oci-reference.md
+++ b/publish-oci-reference.md
@@ -14,7 +14,7 @@ Container publishing can be enabled with one of the following gestures:
 Console apps additionally require installing a NuGet package.
 
 ```bash
-$ dotnet add package Microsoft.NET.Build.Containers --version 8.0.100-rc.2.23480.5
+$ dotnet add package Microsoft.NET.Build.Containers --version 8.0.100
 ```
 
 ## Configure publishing

--- a/publish-oci.md
+++ b/publish-oci.md
@@ -14,9 +14,8 @@ The easiest way to publish an app to a container image is with .NET SDK OCI imag
 Create and run app.
 
 ```bash
-$ mkdir hello-dotnet
-$ cd hello-dotnet/
-$ dotnet new console
+$ dotnet new console -n hello-dotnet
+$ cd hello-dotnet
 $ dotnet run
 Hello, World!
 ```
@@ -24,7 +23,7 @@ Hello, World!
 Add package
 
 ```bash
-$ dotnet add package Microsoft.NET.Build.Containers --version 8.0.100-rc.2.23480.5
+$ dotnet add package Microsoft.NET.Build.Containers --version 8.0.100
 ```
 
 Change the program (so that it will print the name of the operating system):
@@ -65,17 +64,15 @@ $ dotnet publish /t:PublishContainer
 MSBuild version 17.8.0+6cdef4241 for .NET
   Determining projects to restore...
   All projects are up-to-date for restore.
-/home/rich/dotnet-rc2/sdk/8.0.100-rc.2.23502.2/Sdks/Microsoft.NET.Sdk/targets/Microsoft.NET.RuntimeIdentifierInference.targets(311,5): message NETSDK1057: You are using a preview version of .NET. See: https://aka.ms/dotnet-support-policy [/home/rich/hello-dotnet/hello-dotnet.csproj]
   hello-dotnet -> /home/rich/hello-dotnet/bin/Release/net8.0/hello-dotnet.dll
   hello-dotnet -> /home/rich/hello-dotnet/bin/Release/net8.0/publish/
-  Building image 'hello-dotnet' with tags 'latest' on top of base image 'mcr.microsoft.com/dotnet/runtime:8.0.0-rc.2'.
+  Building image 'hello-dotnet' with tags 'latest' on top of base image 'mcr.microsoft.com/dotnet/runtime:8.0'.
   Pushed image 'hello-dotnet:latest' to local registry via 'docker'.
 ```
 
-- Base image downloaded by the SDK: `mcr.microsoft.com/dotnet/runtime:8.0.0-rc.2`
+- Base image downloaded by the SDK: `mcr.microsoft.com/dotnet/runtime:8.0`
 - App image pushed to local daemon: `hello-dotnet:latest`
 
-Note: At the time of writing, the stable version of `Microsoft.NET.Build.Containers` doesn't use the `latest` tag by default. That's why a non-stable version of the package is used. A new stable version will be published with .NET 8 GA.
 
 Look at the image:
 
@@ -102,9 +99,9 @@ $ docker inspect hello-dotnet | grep User
 Audit the image, with [anchore/syft](https://github.com/anchore/syft).
 
 ```bash
-$ docker run --rm anchore/syft mcr.microsoft.com/dotnet/runtime:8.0.0-rc.2 | grep dotnet | wc -l
+$ docker run --rm anchore/syft mcr.microsoft.com/dotnet/runtime:8.0 | grep dotnet | wc -l
 168
-$ docker run --rm anchore/syft mcr.microsoft.com/dotnet/runtime:8.0.0-rc.2 | grep deb | wc -l
+$ docker run --rm anchore/syft mcr.microsoft.com/dotnet/runtime:8.0 | grep deb | wc -l
 92
 ```
 
@@ -127,14 +124,13 @@ $ dotnet publish /t:PublishContainer /p:ContainerFamily=jammy-chiseled /p:Contai
 MSBuild version 17.8.0+6cdef4241 for .NET
   Determining projects to restore...
   All projects are up-to-date for restore.
-/home/rich/dotnet-rc2/sdk/8.0.100-rc.2.23502.2/Sdks/Microsoft.NET.Sdk/targets/Microsoft.NET.RuntimeIdentifierInference.targets(311,5): message NETSDK1057: You are using a preview version of .NET. See: https://aka.ms/dotnet-support-policy [/home/rich/hello-dotnet/hello-dotnet.csproj]
   hello-dotnet -> /home/rich/hello-dotnet/bin/Release/net8.0/hello-dotnet.dll
   hello-dotnet -> /home/rich/hello-dotnet/bin/Release/net8.0/publish/
-  Building image 'hello-chiseled' with tags 'latest' on top of base image 'mcr.microsoft.com/dotnet/runtime:8.0.0-rc.2-jammy-chiseled'.
+  Building image 'hello-chiseled' with tags 'latest' on top of base image 'mcr.microsoft.com/dotnet/runtime:8.0-jammy-chiseled'.
   Pushed image 'hello-chiseled:latest' to local registry via 'docker'.
 ```
 
-- Base image downloaded by the SDK: `mcr.microsoft.com/dotnet/runtime:8.0.0-rc.2-jammy-chiseled`
+- Base image downloaded by the SDK: `mcr.microsoft.com/dotnet/runtime:8.0-jammy-chiseled`
 - App image pushed to local daemon: `hello-chiseled:latest`
 - The image name was specified by the optional `ContainerRepository` property
 
@@ -155,11 +151,11 @@ The image is significantly smaller.
 Audit the image, with [anchore/syft](https://github.com/anchore/syft).
 
 ```bash
-$ docker run --rm anchore/syft mcr.microsoft.com/dotnet/runtime:8.0.0-rc.2-jammy-chiseled | grep dotnet | wc -l
+$ docker run --rm anchore/syft mcr.microsoft.com/dotnet/runtime:8.0-jammy-chiseled | grep dotnet | wc -l
 168
-$ docker run --rm anchore/syft mcr.microsoft.com/dotnet/runtime:8.0.0-rc.2-jammy-chiseled | grep deb | wc -l
+$ docker run --rm anchore/syft mcr.microsoft.com/dotnet/runtime:8.0-jammy-chiseled | grep deb | wc -l
 7
-$ docker run --rm anchore/syft mcr.microsoft.com/dotnet/runtime:8.0.0-rc.2-jammy-chiseled | grep deb
+$ docker run --rm anchore/syft mcr.microsoft.com/dotnet/runtime:8.0-jammy-chiseled | grep deb
 base-files                                         12ubuntu4.4               de     
 ca-certificates                                    20230311ubuntu0.22.04.1   de     
 libc6                                              2.35-0ubuntu3.4           de     
@@ -176,34 +172,31 @@ There are 168 .NET and 7 `.deb` packages/libraries installed. That's a dramatic 
 The same app can be publish for Alpine. The .NET SDK (naturally) knows a lot about the app you are trying to build, including whether you are targeting `linux` (glibc) or `linux-musl` (musl libc; Alpine). However, that [doesn't currently affect OCI publish](https://github.com/dotnet/sdk-container-builds/issues/301), but should. If you want to target Alpine, `ContainerFamily` must be used.
 
 ```bash
-$ dotnet publish /t:PublishContainer --os linux-musl /p:ContainerFamily=alpine3.18 /p:ContainerRepository=hello-musl
+$ dotnet publish /t:PublishContainer --os linux-musl /p:ContainerFamily=alpine /p:ContainerRepository=hello-musl
 $ docker run --rm hello-musl
 Hello, Alpine Linux v3.18!
 ```
 
-Note: due to the way that pre-release builds work, a fully-qualified Alpine verison must be specififed. After .NET 8 is stable, then `ContainerFamily=alpine` will also work (and may be preferable).
-
 Publish should look like the following.
 
 ```bash
-$ dotnet publish /t:PublishContainer --os linux-musl /p:ContainerFamily=alpine3.18 /p:ContainerRepository=hello-musl
+$ dotnet publish /t:PublishContainer --os linux-musl /p:ContainerFamily=alpine /p:ContainerRepository=hello-musl
 MSBuild version 17.8.0+6cdef4241 for .NET
   Determining projects to restore...
   Restored /home/rich/hello-dotnet/hello-dotnet.csproj (in 237 ms).
-/home/rich/dotnet-rc2/sdk/8.0.100-rc.2.23502.2/Sdks/Microsoft.NET.Sdk/targets/Microsoft.NET.RuntimeIdentifierInference.targets(311,5): message NETSDK1057: You are using a preview version of .NET. See: https://aka.ms/dotnet-support-policy [/home/rich/hello-dotnet/hello-dotnet.csproj]
   hello-dotnet -> /home/rich/hello-dotnet/bin/Release/net8.0/linux-musl-x64/hello-dotnet.dll
   hello-dotnet -> /home/rich/hello-dotnet/bin/Release/net8.0/linux-musl-x64/publish/
-  Building image 'hello-musl' with tags 'latest' on top of base image 'mcr.microsoft.com/dotnet/runtime:8.0.0-rc.2-alpine3.18'.
+  Building image 'hello-musl' with tags 'latest' on top of base image 'mcr.microsoft.com/dotnet/runtime:8.0-alpine'.
   Pushed image 'hello-musl:latest' to local registry via 'docker'.
 ```
 
-The `mcr.microsoft.com/dotnet/runtime:8.0.0-rc.2-alpine3.18` base image was used.
+The `mcr.microsoft.com/dotnet/runtime:8.0-alpine` base image was used.
 
 ```bash
 $ docker images hello-musl
 REPOSITORY   TAG       IMAGE ID       CREATED         SIZE
 hello-musl   latest    30cab2de6a37   9 minutes ago   83MB
-$ docker run --rm anchore/syft mcr.microsoft.com/dotnet/runtime:8.0.0-rc.2-alpine3.18 | grep apk | wc -l
+$ docker run --rm anchore/syft mcr.microsoft.com/dotnet/runtime:8.0-alpine | grep apk | wc -l
 17
 ```
 
@@ -214,7 +207,7 @@ As expected, Alpine is significantly smaller than Debian and about the same size
 The same app can be published as self-contained. We'll use chiseled again.
 
 ```bash
-$ dotnet publish /t:PublishContainer /p:ContainerFamily=jammy-chiseled /p:ContainerRepository=hello-chiseled-trimmed /p:PublishTrimmed=true --sc
+$ dotnet publish /t:PublishContainer /p:ContainerFamily=jammy-chiseled /p:ContainerRepository=hello-chiseled-trimmed /p:PublishTrimmed=true --self-contained
 $ docker images hello-chiseled-trimmed
 REPOSITORY               TAG       IMAGE ID       CREATED         SIZE
 hello-chiseled-trimmed   latest    8a166d24b139   6 seconds ago   33.6MB
@@ -225,22 +218,21 @@ Hello, Ubuntu 22.04.3 LTS!
 This image is a lot smaller. Publish should look like the following.
 
 ```bash
-$ dotnet publish /t:PublishContainer /p:ContainerFamily=jammy-chiseled /p:ContainerRepository=hello-chiseled-trimmed /p:PublishTrimmed=true --sc
+$ dotnet publish /t:PublishContainer /p:ContainerFamily=jammy-chiseled /p:ContainerRepository=hello-chiseled-trimmed /p:PublishTrimmed=true --self-contained
 MSBuild version 17.8.0+6cdef4241 for .NET
   Determining projects to restore...
   Restored /home/rich/hello-dotnet/hello-dotnet.csproj (in 844 ms).
-/home/rich/dotnet-rc2/sdk/8.0.100-rc.2.23502.2/Sdks/Microsoft.NET.Sdk/targets/Microsoft.NET.RuntimeIdentifierInference.targets(311,5): message NETSDK1057: You are using a preview version of .NET. See: https://aka.ms/dotnet-support-policy [/home/rich/hello-dotnet/hello-dotnet.csproj]
   hello-dotnet -> /home/rich/hello-dotnet/bin/Release/net8.0/linux-x64/hello-dotnet.dll
   Optimizing assemblies for size. This process might take a while.
   hello-dotnet -> /home/rich/hello-dotnet/bin/Release/net8.0/linux-x64/publish/
-  Building image 'hello-chiseled-trimmed' with tags 'latest' on top of base image 'mcr.microsoft.com/dotnet/runtime-deps:8.0.0-rc.2-jammy-chiseled'.
+  Building image 'hello-chiseled-trimmed' with tags 'latest' on top of base image 'mcr.microsoft.com/dotnet/runtime-deps:8.0-jammy-chiseled'.
   Pushed image 'hello-chiseled-trimmed:latest' to local registry via 'docker'.
 ```
 
-`mcr.microsoft.com/dotnet/runtime-deps:8.0.0-rc.2-jammy-chiseled` is used as the base image. It contains .NET runtime dependencies, only.
+`mcr.microsoft.com/dotnet/runtime-deps:8.0-jammy-chiseled` is used as the base image. It contains .NET runtime dependencies, only.
 
 ```bash
-$ docker run --rm anchore/syft mcr.microsoft.com/dotnet/runtime-deps:8.0.0-rc.2-jammy-chiseled
+$ docker run --rm anchore/syft mcr.microsoft.com/dotnet/runtime-deps:8.0-jammy-chiseled
 NAME             VERSION                   TYPE 
 base-files       12ubuntu4.4               deb   
 ca-certificates  20230311ubuntu0.22.04.1   deb   
@@ -249,7 +241,7 @@ libgcc-s1        12.3.0-1ubuntu1~22.04     deb
 libssl3          3.0.2-0ubuntu1.10         deb   
 libstdc++6       12.3.0-1ubuntu1~22.04     deb   
 zlib1g           1:1.2.11.dfsg-2ubuntu9.2  deb
-$ docker run --rm anchore/syft mcr.microsoft.com/dotnet/runtime-deps:8.0.0-rc.2-jammy-chiseled | grep deb | wc -l
+$ docker run --rm anchore/syft mcr.microsoft.com/dotnet/runtime-deps:8.0-jammy-chiseled | grep deb | wc -l
 7
 ```
 
@@ -278,7 +270,7 @@ $ cat hello-dotnet.csproj
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Build.Containers" Version="8.0.100-rc.2.23480.5" />
+    <PackageReference Include="Microsoft.NET.Build.Containers" Version="8.0.100" />
   </ItemGroup>
 
 </Project>
@@ -291,11 +283,10 @@ $ dotnet publish /t:PublishContainer
 MSBuild version 17.8.0+6cdef4241 for .NET
   Determining projects to restore...
   Restored /home/rich/hello-dotnet/hello-dotnet.csproj (in 221 ms).
-/home/rich/dotnet-rc2/sdk/8.0.100-rc.2.23502.2/Sdks/Microsoft.NET.Sdk/targets/Microsoft.NET.RuntimeIdentifierInference.targets(311,5): message NETSDK1057: You are using a preview version of .NET. See: https://aka.ms/dotnet-support-policy [/home/rich/hello-dotnet/hello-dotnet.csproj]
   hello-dotnet -> /home/rich/hello-dotnet/bin/Release/net8.0/linux-x64/hello-dotnet.dll
   Optimizing assemblies for size. This process might take a while.
   hello-dotnet -> /home/rich/hello-dotnet/bin/Release/net8.0/linux-x64/publish/
-  Building image 'hello-chiseled-trimmed' with tags 'latest' on top of base image 'mcr.microsoft.com/dotnet/runtime-deps:8.0.0-rc.2-jammy-chiseled'.
+  Building image 'hello-chiseled-trimmed' with tags 'latest' on top of base image 'mcr.microsoft.com/dotnet/runtime-deps:8.0-jammy-chiseled'.
   Pushed image 'hello-chiseled-trimmed:latest' to local registry via 'docker'.
 ```
 
@@ -319,9 +310,8 @@ $ dotnet publish /t:PublishContainer
 MSBuild version 17.8.0+6cdef4241 for .NET
   Determining projects to restore...
   Restored /home/rich/hello-dotnet/hello-dotnet.csproj (in 254 ms).
-/home/rich/dotnet-rc2/sdk/8.0.100-rc.2.23502.2/Sdks/Microsoft.NET.Sdk/targets/Microsoft.NET.RuntimeIdentifierInference.targets(311,5): message NETSDK1057: You are using a preview version of .NET. See: https://aka.ms/dotnet-support-policy [/home/rich/hello-dotnet/hello-dotnet.csproj]
   hello-dotnet -> /home/rich/hello-dotnet/bin/Release/net8.0/linux-x64/hello-dotnet.dll
-/home/rich/.nuget/packages/microsoft.dotnet.ilcompiler/8.0.0-rc.2.23479.6/build/Microsoft.NETCore.Native.Unix.targets(199,5): error : Platform linker ('clang' or 'gcc') not found in PATH. Ensure you have all the required prerequisites documented at https://aka.ms/nativeaot-prerequisites. [/home/rich/hello-dotnet/hello-dotnet.csproj]
+/home/rich/.nuget/packages/microsoft.dotnet.ilcompiler/8.0.0/build/Microsoft.NETCore.Native.Unix.targets(199,5): error : Platform linker ('clang' or 'gcc') not found in PATH. Ensure you have all the required prerequisites documented at https://aka.ms/nativeaot-prerequisites. [/home/rich/hello-dotnet/hello-dotnet.csproj]
 ```
 
 You will get this error if you don't have a native toolchain installed.
@@ -343,15 +333,14 @@ $ dotnet publish /t:PublishContainer
 MSBuild version 17.8.0+6cdef4241 for .NET
   Determining projects to restore...
   All projects are up-to-date for restore.
-/home/rich/dotnet-rc2/sdk/8.0.100-rc.2.23502.2/Sdks/Microsoft.NET.Sdk/targets/Microsoft.NET.RuntimeIdentifierInference.targets(311,5): message NETSDK1057: You are using a preview version of .NET. See: https://aka.ms/dotnet-support-policy [/home/rich/hello-dotnet/hello-dotnet.csproj]
   hello-dotnet -> /home/rich/hello-dotnet/bin/Release/net8.0/linux-x64/hello-dotnet.dll
   Generating native code
   hello-dotnet -> /home/rich/hello-dotnet/bin/Release/net8.0/linux-x64/publish/
-  Building image 'hello-chiseled-aot' with tags 'latest' on top of base image 'mcr.microsoft.com/dotnet/runtime-deps:8.0.0-rc.2-jammy-chiseled'.
+  Building image 'hello-chiseled-aot' with tags 'latest' on top of base image 'mcr.microsoft.com/dotnet/runtime-deps:8.0-jammy-chiseled'.
   Pushed image 'hello-chiseled-aot:latest' to local registry via 'docker'.
 ```
 
-The `mcr.microsoft.com/dotnet/runtime-deps:8.0.0-rc.2-jammy-chiseled` base image is used.
+The `mcr.microsoft.com/dotnet/runtime-deps:8.0-jammy-chiseled` base image is used.
 
 Notice `Generating native code`. That's specific to native AOT publishing.
 
@@ -368,7 +357,7 @@ This app is even smaller and includes 8 components, the same as was seen for the
 $ docker images hello-chiseled-aot
 REPOSITORY           TAG       IMAGE ID       CREATED         SIZE
 hello-chiseled-aot   latest    b6e41eefd53c   3 minutes ago   17.4MB
-docker run --rm anchore/syft mcr.microsoft.com/dotnet/runtime-deps:8.0.0-rc.2-jammy-chiseled
+$ docker run --rm anchore/syft mcr.microsoft.com/dotnet/runtime-deps:8.0-jammy-chiseled
 NAME             VERSION                   TYPE 
 base-files       12ubuntu4.4               deb   
 ca-certificates  20230311ubuntu0.22.04.1   deb   
@@ -377,7 +366,7 @@ libgcc-s1        12.3.0-1ubuntu1~22.04     deb
 libssl3          3.0.2-0ubuntu1.10         deb   
 libstdc++6       12.3.0-1ubuntu1~22.04     deb   
 zlib1g           1:1.2.11.dfsg-2ubuntu9.2  deb
-rich@vancouver:~/hello-dotnet$ docker run --rm anchore/syft mcr.microsoft.com/dotnet/runtime-deps:8.0.0-rc.2-jammy-chiseled | wc -l
+$ docker run --rm anchore/syft mcr.microsoft.com/dotnet/runtime-deps:8.0-jammy-chiseled | wc -l
 8
 ```
 
@@ -395,13 +384,12 @@ $ dotnet publish /t:PublishContainer
 MSBuild version 17.8.0+6cdef4241 for .NET
   Determining projects to restore...
   All projects are up-to-date for restore.
-/home/rich/dotnet-rc2/sdk/8.0.100-rc.2.23502.2/Sdks/Microsoft.NET.Sdk/targets/Microsoft.NET.RuntimeIdentifierInference.targets(311,5): message NETSDK1057: You are using a preview version of .NET. See: https://aka.ms/dotnet-support-policy [/home/rich/hello-dotnet/hello-dotnet.csproj]
   hello-dotnet -> /home/rich/hello-dotnet/bin/Release/net8.0/linux-x64/hello-dotnet.dll
   Generating native code
   hello-dotnet -> /home/rich/hello-dotnet/bin/Release/net8.0/linux-x64/publish/
   Building image 'hello-chiseled-aot' with tags 'latest' on top of base image 'mcr.microsoft.com/dotnet/nightly/runtime-deps:8.0-jammy-chiseled-aot'.
   Pushed image 'hello-chiseled-aot:latest' to local registry via 'docker'.
-rich@vancouver:~/hello-dotnet$ docker images hello-chiseled-aot
+$ docker images hello-chiseled-aot
 REPOSITORY           TAG       IMAGE ID       CREATED         SIZE
 hello-chiseled-aot   latest    4d866101f112   5 seconds ago   15.1MB
 ```
@@ -417,6 +405,6 @@ libc6            2.35-0ubuntu3.4           deb
 libgcc-s1        12.3.0-1ubuntu1~22.04     deb   
 libssl3          3.0.2-0ubuntu1.10         deb   
 zlib1g           1:1.2.11.dfsg-2ubuntu9.2  deb
-rich@vancouver:~/hello-dotnet$ docker run --rm anchore/syft mcr.microsoft.com/dotnet/nightly/runtime-deps:8.0-jammy-chiseled-aot | wc -l
+$ docker run --rm anchore/syft mcr.microsoft.com/dotnet/nightly/runtime-deps:8.0-jammy-chiseled-aot | wc -l
 7
 ```


### PR DESCRIPTION
* Stabilize packagereference versions
* Stabilize references to .NET Container base image versions
* remove .NET SDK warning messages about using preview SDKs